### PR TITLE
more callbacks, less namespaces

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -34,6 +34,7 @@ export default function App() {
                 <Route path="/email-confirmed" element={<EmailConfirmed />} />
                 <Route path="/forgot-password" element={<ForgotPassword />} />
                 <Route path="/profile/:displayedUserId" element={<Profile />} />
+                <Route path="/profile" element={<Profile />} />
                 <Route path="/room" element={<Room />} />
                 <Route path="/explore" element={<Explore />} />
             </Routes>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,7 +17,7 @@ export default function App() {
                 duration={4000}
                 toastOptions={{
                     style: {
-                        color: 'var(--destructive)',
+                        color: 'var(--foreground)',
                         background: 'var(--card)',
                         borderColor: 'var(--border)',
                         fontFamily: 'Pixuf, sans-serif',

--- a/src/api/auth/login.ts
+++ b/src/api/auth/login.ts
@@ -13,8 +13,8 @@ export type LoginError = {
 
 const validateInputs = (loginRequest: LoginRequest): string[] => {
     const errors: string[] = [];
-    errors.push(...AuthFieldValidation.ValidateUsername(loginRequest.username));
-    errors.push(...AuthFieldValidation.ValidatePassword(loginRequest.password));
+    errors.push(...AuthFieldValidation.validateUsername(loginRequest.username));
+    errors.push(...AuthFieldValidation.validatePassword(loginRequest.password));
     return errors;
 }
 

--- a/src/api/auth/logout.ts
+++ b/src/api/auth/logout.ts
@@ -1,11 +1,6 @@
 import { endpoints } from "../endpoints";
 
-export type LogoutError = {
-    detail?: string
-    errors: string[]
-}
-
-export const logout = async (): Promise<void | LogoutError> => {
+export const logout = async (onError: (description: string) => void): Promise<boolean> => {
 
     try {
         const response = await fetch(endpoints.auth.logout(), {
@@ -17,20 +12,16 @@ export const logout = async (): Promise<void | LogoutError> => {
         });
 
         if (response.ok){
-            return;
+            return true;
         }
 
-        return {
-            detail: "Logout failed.",
-            errors: [],
-        };
+        onError("Logout failed.");
+        return false;
     }
     
     catch (error) {
-        return {
-            detail: "Network or unexpected error",
-            errors: [error instanceof Error ? error.message : String(error)],
-        };
+        onError("Logout failed: Network or unexpected error");
+        return false;
     }
 
 }

--- a/src/api/auth/register.ts
+++ b/src/api/auth/register.ts
@@ -17,9 +17,9 @@ const validateInputs = (registerRequest: RegisterRequest): string[] => {
 
     const errors: string[] = [];
 
-    errors.push(...AuthFieldValidation.ValidateUsername(registerRequest.username));
-    errors.push(...AuthFieldValidation.ValidateEmail(registerRequest.email));
-    errors.push(...AuthFieldValidation.ValidatePassword(registerRequest.password));
+    errors.push(...AuthFieldValidation.validateUsername(registerRequest.username));
+    errors.push(...AuthFieldValidation.validateEmail(registerRequest.email));
+    errors.push(...AuthFieldValidation.validatePassword(registerRequest.password));
 
     if(registerRequest.password != registerRequest.confirmPassword){
         errors.push("Passwords do not match.");

--- a/src/api/auth/register.ts
+++ b/src/api/auth/register.ts
@@ -29,7 +29,7 @@ const validateInputs = (registerRequest: RegisterRequest): string[] => {
 
 }
 
-export const register = async (registerRequest: RegisterRequest): Promise<void | RegisterError> => {
+export const register = async (registerRequest: RegisterRequest, onSuccess: (description: string) => void): Promise<void | RegisterError> => {
     try {
 
         const validationErrors: string[] = validateInputs(registerRequest);
@@ -49,6 +49,7 @@ export const register = async (registerRequest: RegisterRequest): Promise<void |
         });
         
         if (response.ok){
+            onSuccess("Verification email sent!")
             return;
         }
 

--- a/src/api/auth/validation.ts
+++ b/src/api/auth/validation.ts
@@ -1,7 +1,6 @@
-export namespace AuthFieldValidation {
+export const AuthFieldValidation = {
 
-    export const ValidateUsername = (username: string): string[] => {
-
+    validateUsername: (username: string): string[] => {
         const MIN_USERNAME_LENGTH = 3
         const MAX_USERNAME_LENGTH = 24
         const errors: string[] = [];
@@ -16,10 +15,9 @@ export namespace AuthFieldValidation {
         }
 
         return errors;
-    } 
+    },
 
-    export const ValidateEmail = (email: string): string[] => {
-
+    validateEmail: (email: string): string[] => {
         const errors: string[] = [];
 
         const emailRegex = /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/;
@@ -28,10 +26,9 @@ export namespace AuthFieldValidation {
         }
 
         return errors;
-    }
+    },
 
-    export const ValidatePassword = (password: string): string[] => {
-    
+    validatePassword: (password: string): string[] => {
         const MIN_PASSWORD_LENGTH = 12
         const errors: string[] = [];
 
@@ -45,7 +42,6 @@ export namespace AuthFieldValidation {
         }
 
         return errors;
-
-    }
+    },
 
 }

--- a/src/components/profile-dropdown.tsx
+++ b/src/components/profile-dropdown.tsx
@@ -4,6 +4,7 @@ import { ProfilePicture } from "./profile-picture";
 import { Link } from "react-router-dom";
 import { User } from "@/api/users/user";
 import { logout } from "@/api/auth/logout";
+import { Toasts } from "@/utils/toasts";
 
 interface ProfileDropdownProps {
     user: User
@@ -12,9 +13,8 @@ interface ProfileDropdownProps {
 export const ProfileDropdown = ({ user }: ProfileDropdownProps) => {
 
     const handleLogout = async (): Promise<void> => {
-        const result = await logout();
-        if (result) {
-            console.error("Logout failed:", result);
+        const isLogoutSuccessful = await logout((description: string) => {Toasts.error(description)});
+        if (!isLogoutSuccessful) {
             return;
         }
         window.location.reload();

--- a/src/components/register-dialog.tsx
+++ b/src/components/register-dialog.tsx
@@ -6,6 +6,7 @@ import { Label } from "./ui/label";
 import { register, RegisterError, RegisterRequest } from "@/api/auth/register";
 import { LoginRequest } from "@/api/auth/login";
 import { useAuthStore } from "@/hooks/use-auth-store";
+import { Toasts } from "@/utils/toasts";
 
 export const RegisterDialog = () => {
 
@@ -31,7 +32,7 @@ export const RegisterDialog = () => {
             confirmPassword: formData.get("confirm-password") as string,
         };
 
-        const registerError = await register(registerRequest);
+        const registerError = await register(registerRequest, (description: string) => {Toasts.success(description)});
 
         if (registerError) {
             setErrors(registerError);

--- a/src/pages/profile.tsx
+++ b/src/pages/profile.tsx
@@ -57,7 +57,7 @@ export const Profile = () => {
         const request: FollowRequest = {
             followeeId: displayedUser.id
         }
-        const followResult = await FollowService.follow(request, (description: string) => {Toasts.Error(description)});
+        const followResult = await FollowService.follow(request, (description: string) => {Toasts.error(description)});
         if(followResult){
             setDisplayedUser({
                 ...displayedUser,
@@ -74,7 +74,7 @@ export const Profile = () => {
         const request: UnfollowRequest = {
             followeeId: displayedUser.id,
         }
-        const unfollowResult = await FollowService.unfollow(request, (description: string) => {Toasts.Error(description)});
+        const unfollowResult = await FollowService.unfollow(request, (description: string) => {Toasts.error(description)});
         if(unfollowResult){
             setDisplayedUser({
                 ...displayedUser,

--- a/src/pages/profile.tsx
+++ b/src/pages/profile.tsx
@@ -29,13 +29,14 @@ export const Profile = () => {
 
     useEffect(() => {
         const fetchDisplayedUser = async () => {
-            if(!user || !displayedUserId) return; //todo: redirect to home
-            const isViewingOwnProfile: boolean = user.id === displayedUserId;
+            if(!user) return;
+            const profileId = displayedUserId ?? user.id; 
+            const isViewingOwnProfile: boolean = user.id === profileId;
             if(isViewingOwnProfile){
                 setDisplayedUser(user);
             }
             else{
-                const profile = await UserService.profile(displayedUserId);
+                const profile = await UserService.profile(profileId);
                 setDisplayedUser(profile ? profile.user : null);
                 setIsFollowing(profile ? profile.isFollowing : false);
             }

--- a/src/utils/toasts.ts
+++ b/src/utils/toasts.ts
@@ -5,12 +5,18 @@ export const Toasts = {
     success: (description: string): void => {
         toast("Success", {
             description: description,
+            style: {
+                color: 'var(--timesynq-green)',
+            },
         })
     },
 
     error: (description: string): void => {
         toast("Error", {
             description: description,
+            style: {
+                color: 'var(--destructive)',
+            },
         })
     }
 

--- a/src/utils/toasts.ts
+++ b/src/utils/toasts.ts
@@ -1,8 +1,14 @@
 import { toast } from "sonner"
 
-export namespace Toasts {
+export const Toasts = {
 
-    export const Error = (description: string): void => {
+    success: (description: string): void => {
+        toast("Success", {
+            description: description,
+        })
+    },
+
+    error: (description: string): void => {
         toast("Error", {
             description: description,
         })


### PR DESCRIPTION
-remove AuthFieldValidation namespace and replace it with an object of the same name
-remove Toasts namespace and replace it with an object of the same name
-add onError callback to logout, hooked up to a toast in ProfileDropdown
-add onSuccess callback to register, hooked up to toast in RegisterDialog
-add Success toast
-profile page with no id path parameter will default to the signed in user